### PR TITLE
Enable opening files from Finder on MacOS X

### DIFF
--- a/BeeRef.spec
+++ b/BeeRef.spec
@@ -61,4 +61,12 @@ if sys.platform == 'darwin':
         exe,
         name=f'{appname}.app',
         icon=join('beeref', 'assets', icon),
-        bundle_identifier=None)
+        bundle_identifier=None,
+        info_plist={
+            'CFBundleDocumentTypes': [
+                {
+                    'CFBundleTypeExtensions': [ 'bee' ],
+                    'CFBundleTypeRole': 'Viewer'
+                }
+            ]
+        })

--- a/beeref/__main__.py
+++ b/beeref/__main__.py
@@ -30,6 +30,19 @@ from beeref.view import BeeGraphicsView
 logger = logging.getLogger(__name__)
 
 
+class BeeRefApplication(QtWidgets.QApplication):
+
+    def event(self, event):
+        if event.type() == QtCore.QEvent.Type.FileOpen:
+            for widget in self.topLevelWidgets():
+                if isinstance(widget, BeeRefMainWindow):
+                    widget.view.open_from_file(event.file())
+                    return True
+            return False
+        else:
+            return super().event(event)
+
+
 class BeeRefMainWindow(QtWidgets.QMainWindow):
 
     def __init__(self, app):
@@ -79,7 +92,7 @@ def main():
     logger.info(f'Using settings: {settings.fileName()}')
     logger.info(f'Logging to: {logfile_name()}')
     CommandlineArgs(with_check=True)  # Force checking
-    app = QtWidgets.QApplication(sys.argv)
+    app = BeeRefApplication(sys.argv)
     palette = create_palette_from_dict(constants.COLORS)
     app.setPalette(palette)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,3 +87,9 @@ def tmpfile(tmpdir):
 def item():
     from beeref.items import BeePixmapItem
     yield BeePixmapItem(QtGui.QImage())
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    from beeref.__main__ import BeeRefApplication
+    yield BeeRefApplication([])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from PyQt6 import QtCore
 
@@ -18,7 +18,16 @@ def test_beeref_mainwindow_init(show_mock, qapp):
     show_mock.assert_called()
 
 
-@patch('PyQt6.QtWidgets.QApplication')
+@patch('beeref.view.BeeGraphicsView.open_from_file')
+def test_beerefapplication_fileopenevent(open_mock, qapp, main_window):
+    event = MagicMock()
+    event.type.return_value = QtCore.QEvent.Type.FileOpen
+    event.file.return_value = 'test.bee'
+    assert qapp.event(event) is True
+    open_mock.assert_called_once_with('test.bee')
+
+
+@patch('beeref.__main__.BeeRefApplication')
 @patch('beeref.__main__.CommandlineArgs')
 def test_main(args_mock, app_mock, qapp):
     app_mock.return_value = qapp


### PR DESCRIPTION
With this code, MacOS X user can double click `.bee` file and it gets opened in BeeRef.