### PR TITLE
MacOS X tweaks

### DIFF
--- a/BeeRef.spec
+++ b/BeeRef.spec
@@ -59,9 +59,10 @@ exe = EXE(
 if sys.platform == 'darwin':
     app = BUNDLE(
         exe,
-        name=f'{appname}.app',
+        name=f'{constants.APPNAME}.app',
         icon=join('beeref', 'assets', icon),
-        bundle_identifier=None,
+        bundle_identifier='org.beeref.app',
+        version=f'{constants.VERSION}',
         info_plist={
             'CFBundleDocumentTypes': [
                 {


### PR DESCRIPTION
- put version in the app bundle
- do not include version in the .app bundle name

Closes #19