### PR TITLE
Add missing widgets package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'beeref.assets',
         'beeref.documentation',
         'beeref.fileio',
+        'beeref.widgets',
     ],
     entry_points={
         'gui_scripts': [


### PR DESCRIPTION
The setup.py file is missing the `widgets` package/directory.

When beeref is installed through that, it fails to start:

```
Traceback (most recent call last):
  File "/usr/bin/beeref", line 33, in <module>
    sys.exit(load_entry_point('BeeRef==0.3.2', 'gui_scripts', 'beeref')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/beeref", line 25, in importlib_load_entry_point
    return next(matches).load()
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3.11/site-packages/beeref/__main__.py", line 30, in <module>
    from beeref.view import BeeGraphicsView
  File "/usr/lib/python3.11/site-packages/beeref/view.py", line 30, in <module>
    from beeref import widgets
ImportError: cannot import name 'widgets' from 'beeref' (/usr/lib/python3.11/site-packages/beeref/__init__.py)
```