### PR TITLE
appdata: Use screenshot direct raw link

### DIFF
--- a/org.beeref.BeeRef.appdata.xml
+++ b/org.beeref.BeeRef.appdata.xml
@@ -14,9 +14,9 @@
     </description>
 
     <screenshots>
-      <screenshot type="default">
-        <image>https://github.com/rbreu/beeref/blob/main/images/screenshot.png?raw=true</image>
-      </screenshot>
+        <screenshot type="default">
+            <image>https://raw.githubusercontent.com/rbreu/beeref/main/images/screenshot.png</image>
+        </screenshot>
     </screenshots>
 
     <releases>


### PR DESCRIPTION
Otherwise appstream validation will fail with screenshot-no-media error