### PR TITLE
Disable keyrepeat for shortcuts

### DIFF
--- a/beeref/actions/mixin.py
+++ b/beeref/actions/mixin.py
@@ -70,6 +70,7 @@ class ActionsMixin:
     def _create_actions(self):
         for action in actions.values():
             qaction = QtGui.QAction(action.text, self)
+            qaction.setAutoRepeat(False)
             shortcuts = action.get_shortcuts()
             if shortcuts:
                 qaction.setShortcuts(shortcuts)


### PR DESCRIPTION
Currently the keyboard shortcut actions gets repeated when holding down the shortcut keys. I don't think this is intentional as I didn't find any shortcuts that would benefit from this behavior. 

Besides just being a bit annoying, this could also lead to crashes as the program would get into an undefined state.

For example if you held down the crop shortcut key (shift + c) and clicked outside of the crop hot zones, beeref would crash most of the time.