### PR TITLE
Fix crash when dragging an image and toggling on crop mode

### DIFF
--- a/beeref/items.py
+++ b/beeref/items.py
@@ -584,7 +584,7 @@ class BeePixmapItem(BeeItemMixin, QtWidgets.QGraphicsPixmapItem):
         return point
 
     def mouseMoveEvent(self, event):
-        if self.crop_mode:
+        if self.crop_mode and self.crop_mode_event_start:
             diff = event.pos() - self.crop_mode_event_start
             if self.crop_mode_move == self.crop_handle_topleft:
                 new = self.ensure_point_within_crop_bounds(


### PR DESCRIPTION
`crop_mode_event_start` would be set to `None` and thus crash the program. Add a check for this.

Note that going into crop mode can crash in different ways without #113. So this only fixes the crash I was able to reproduce with #113 applied.