### PR TITLE
Make moving the crop rectangle possible, tweak accept/cancel behaviour

### DIFF
--- a/beeref/items.py
+++ b/beeref/items.py
@@ -539,9 +539,42 @@ class BeePixmapItem(BeeItemMixin, QtWidgets.QGraphicsPixmapItem):
                 self.crop_mode_event_start = event.pos()
                 self.crop_mode_move = edge
                 return
+        if self.crop_temp.contains(event.pos()):
+            self.crop_mode_event_start = event.pos()
+            self.crop_mode_move = self.crop_temp
+            return
         # Click not in handle, end cropping mode:
-        self.exit_crop_mode(
-            confirm=self.crop_temp.contains(event.pos()))
+        self.exit_crop_mode(confirm=True)
+
+    def mouseDoubleClickEvent(self, event):
+        if not self.crop_mode:
+            return super().mouseDoubleClickEvent(event)
+
+        event.accept()
+        if self.crop_temp.contains(event.pos()):
+            self.exit_crop_mode(confirm=True)
+
+    def ensure_crop_box_is_inside(self, point):
+        """Returns the modified point that ensures that the crop rectangle is
+        still withint the pixmap.
+
+        The point passed is assumed to be the top
+        left crop rectangle position.
+        """
+
+        max_x_pos = self.pixmap().size().width() - self.crop_temp.width()
+        max_y_pos = self.pixmap().size().height() - self.crop_temp.height()
+
+        if point.x() < 0:
+            point.setX(0)
+        elif point.x() > max_x_pos:
+            point.setX(max_x_pos)
+
+        if point.y() < 0:
+            point.setY(0)
+        elif point.y() > max_y_pos:
+            point.setY(max_y_pos)
+        return point
 
     def ensure_point_within_crop_bounds(self, point, handle):
         """Returns the point, or the nearest point within the pixmap."""
@@ -549,31 +582,31 @@ class BeePixmapItem(BeeItemMixin, QtWidgets.QGraphicsPixmapItem):
         if handle == self.crop_handle_topleft:
             topleft = QtCore.QPointF(0, 0)
             bottomright = self.crop_temp.bottomRight()
-        if handle == self.crop_handle_bottomleft:
+        elif handle == self.crop_handle_bottomleft:
             topleft = QtCore.QPointF(0, self.crop_temp.top())
             bottomright = QtCore.QPointF(
                 self.crop_temp.right(), self.pixmap().size().height())
-        if handle == self.crop_handle_bottomright:
+        elif handle == self.crop_handle_bottomright:
             topleft = self.crop_temp.topLeft()
             bottomright = QtCore.QPointF(
                 self.pixmap().size().width(), self.pixmap().size().height())
-        if handle == self.crop_handle_topright:
+        elif handle == self.crop_handle_topright:
             topleft = QtCore.QPointF(self.crop_temp.left(), 0)
             bottomright = QtCore.QPointF(
                 self.pixmap().size().width(), self.crop_temp.bottom())
-        if handle == self.crop_edge_top:
+        elif handle == self.crop_edge_top:
             topleft = QtCore.QPointF(0, 0)
             bottomright = QtCore.QPointF(
                 self.pixmap().size().width(), self.crop_temp.bottom())
-        if handle == self.crop_edge_bottom:
+        elif handle == self.crop_edge_bottom:
             topleft = QtCore.QPointF(0, self.crop_temp.top())
             bottomright = QtCore.QPointF(
                 self.pixmap().size().width(), self.pixmap().size().height())
-        if handle == self.crop_edge_left:
+        elif handle == self.crop_edge_left:
             topleft = QtCore.QPointF(0, 0)
             bottomright = QtCore.QPointF(
                 self.crop_temp.right(), self.pixmap().size().height())
-        if handle == self.crop_edge_right:
+        elif handle == self.crop_edge_right:
             topleft = QtCore.QPointF(self.crop_temp.left(), 0)
             bottomright = QtCore.QPointF(
                 self.pixmap().size().width(), self.pixmap().size().height())
@@ -586,35 +619,38 @@ class BeePixmapItem(BeeItemMixin, QtWidgets.QGraphicsPixmapItem):
     def mouseMoveEvent(self, event):
         if self.crop_mode:
             diff = event.pos() - self.crop_mode_event_start
+            if self.crop_mode_move == self.crop_temp:
+                new = self.ensure_crop_box_is_inside(self.crop_temp.topLeft() + diff)
+                self.crop_temp.moveTo(new)
             if self.crop_mode_move == self.crop_handle_topleft:
                 new = self.ensure_point_within_crop_bounds(
                     self.crop_temp.topLeft() + diff, self.crop_mode_move)
                 self.crop_temp.setTopLeft(new)
-            if self.crop_mode_move == self.crop_handle_bottomleft:
+            elif self.crop_mode_move == self.crop_handle_bottomleft:
                 new = self.ensure_point_within_crop_bounds(
                     self.crop_temp.bottomLeft() + diff, self.crop_mode_move)
                 self.crop_temp.setBottomLeft(new)
-            if self.crop_mode_move == self.crop_handle_bottomright:
+            elif self.crop_mode_move == self.crop_handle_bottomright:
                 new = self.ensure_point_within_crop_bounds(
                     self.crop_temp.bottomRight() + diff, self.crop_mode_move)
                 self.crop_temp.setBottomRight(new)
-            if self.crop_mode_move == self.crop_handle_topright:
+            elif self.crop_mode_move == self.crop_handle_topright:
                 new = self.ensure_point_within_crop_bounds(
                     self.crop_temp.topRight() + diff, self.crop_mode_move)
                 self.crop_temp.setTopRight(new)
-            if self.crop_mode_move == self.crop_edge_top:
+            elif self.crop_mode_move == self.crop_edge_top:
                 new = self.ensure_point_within_crop_bounds(
                     self.crop_temp.topLeft() + diff, self.crop_mode_move)
                 self.crop_temp.setTop(new.y())
-            if self.crop_mode_move == self.crop_edge_left:
+            elif self.crop_mode_move == self.crop_edge_left:
                 new = self.ensure_point_within_crop_bounds(
                     self.crop_temp.topLeft() + diff, self.crop_mode_move)
                 self.crop_temp.setLeft(new.x())
-            if self.crop_mode_move == self.crop_edge_bottom:
+            elif self.crop_mode_move == self.crop_edge_bottom:
                 new = self.ensure_point_within_crop_bounds(
                     self.crop_temp.bottomLeft() + diff, self.crop_mode_move)
                 self.crop_temp.setBottom(new.y())
-            if self.crop_mode_move == self.crop_edge_right:
+            elif self.crop_mode_move == self.crop_edge_right:
                 new = self.ensure_point_within_crop_bounds(
                     self.crop_temp.topRight() + diff, self.crop_mode_move)
                 self.crop_temp.setRight(new.x())

--- a/beeref/scene.py
+++ b/beeref/scene.py
@@ -87,7 +87,7 @@ class BeeGraphicsScene(QtWidgets.QGraphicsScene):
     def cancel_crop_mode(self):
         """Cancels an ongoing crop mode, if there is any."""
         if self.crop_item:
-            self.crop_item.exit_crop_mode(confirm=False)
+            self.crop_item.exit_crop_mode(confirm=True)
 
     def copy_selection_to_internal_clipboard(self):
         self.internal_clipboard = []
@@ -394,6 +394,10 @@ class BeeGraphicsScene(QtWidgets.QGraphicsScene):
         super().mousePressEvent(event)
 
     def mouseDoubleClickEvent(self, event):
+        if self.crop_item:
+            super().mouseDoubleClickEvent(event)
+            return
+
         self.cancel_active_modes()
         item = self.itemAt(event.scenePos(), self.views()[0].transform())
         if item:


### PR DESCRIPTION
I have purposely not yet updated the tests as I think there might be need for some discussion or tweaks from the changes as I'm changing the current default behavior.

While using Beeref myself, I found it very weird that clicking inside of the crop rectangle our confirm and not move the rectangle it self. This lead to a few miss clicks here and there where I would accept the change and have to go back into crop mode again. Granted, the main reason for this PR is to make it possible to move the crop rectangle as I usually want to nudge the whole thing around a bit after cropping.

To be able to confirm, I make it so that if you double click on the crop rect, it will confirm.

While working on this I also realized that the behavior of canceling the crop action by clicking outside of the rectangle felt a bit weird as this is not what happens with the text object. It also makes it less tedious as you don't lose your cropping work if you miss click outside of the rectangle.

Now it is in line with the text box editing workflow where clicking outside will confirm and only escape will undo your changes.

To me all of these changes are for the better, but I realize that no everyone might feel that same way :)