### PR TITLE
Fix pytest commandline flags being parsed by Beeref

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Fixed
   crashes (by DarkDefender)
 * Fixed a crash when pressing the crop shortcut while dragging an image
   (by DarkDefender)
+* Fix commandline arguments meant for pytest being parsed by BeeRef
+  (by DarkDefender)
 
 
 Changed

--- a/beeref/config/settings.py
+++ b/beeref/config/settings.py
@@ -89,7 +89,9 @@ class CommandlineArgs:
             if with_check:
                 self._args = parser.parse_args()
             else:
-                self._args = parser.parse_known_args()[0]
+                # Do not parse any flags from sys.argv as we are
+                # being used as a module.
+                self._args = parser.parse_args([])
 
     def __getattribute__(self, name):
         if name == '_args':

--- a/beeref/config/settings.py
+++ b/beeref/config/settings.py
@@ -80,18 +80,17 @@ class CommandlineArgs:
     _instance = None
 
     def __new__(cls, *args, **kwargs):
-        if not cls._instance or kwargs.get('with_check'):
+        if not cls._instance:
             cls._instance = super().__new__(cls)
         return cls._instance
 
     def __init__(self, with_check=False):
-        if not hasattr(self, '_args'):
-            if with_check:
-                self._args = parser.parse_args()
-            else:
-                # Do not parse any flags from sys.argv as we are
-                # being used as a module.
-                self._args = parser.parse_args([])
+        if with_check:
+            self._args = parser.parse_args()
+        elif not hasattr(self, '_args'):
+            # Do not parse any flags from sys.argv unless speficially
+            # told to do so.
+            self._args = parser.parse_args([])
 
     def __getattribute__(self, name):
         if name == '_args':

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -19,10 +19,12 @@ def test_command_line_args_singleton():
 @patch('beeref.config.settings.parser.parse_args')
 def test_command_line_args_with_check_forces_new_parsing(parse_mock):
     args1 = CommandlineArgs()
+    parse_mock.assert_called_with([])
     args2 = CommandlineArgs(with_check=True)
+    parse_mock.assert_called_with()
     args3 = CommandlineArgs()
     assert parse_mock.call_count == 2
-    assert args1 is not args2
+    assert args1 is args2
     assert args2 is args3
     CommandlineArgs._instance = None
 

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -20,8 +20,10 @@ def test_command_line_args_singleton():
 def test_command_line_args_with_check_forces_new_parsing(parse_mock):
     args1 = CommandlineArgs()
     args2 = CommandlineArgs(with_check=True)
-    parse_mock.assert_called_once()
+    args3 = CommandlineArgs()
+    assert parse_mock.call_count == 2
     assert args1 is not args2
+    assert args2 is args3
     CommandlineArgs._instance = None
 
 


### PR DESCRIPTION
For example, running `pytest -l` will error out as Beeref would try to parse `-l` as a log level flag. Now we no longer try to blindly parse flags when including the Beeref commandline parser.

I ran into this when working on the other PR.